### PR TITLE
Update version 1.1.9: Subject Identifier too long / Hidden hover panel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: megaplots
 Title: A 'shiny' Application for Pattern Detection
-Version: 1.1.8
+Version: 1.1.9
 Authors@R: c(
     person("Madhurima", "Majumder", role = "aut"),
     person("Susanne", "Lippert", role = "aut"),

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -153,7 +153,7 @@ app_server <- function(input, output, session) {
         dplyr::select(-dplyr::all_of(remove_variables))
       #transform Missings to character "NA"
       for(i in 1:dim(tmp$megaplot_data$A)[2]) {
-        if (is.numeric(tmp$megaplot_data$A[,i]) | is.numeric(tmp$megaplot_data$A[,i])) {
+        if (is.numeric(tmp$megaplot_data$A[,i])) {
         } else if (
           inherits(tmp$megaplot_data$A[,i], 'Date')
           ){

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -366,6 +366,16 @@ app_ui <- function(request) {
               value = "Time",
               placeholder = "Time"
             ),
+            shiny::tags$br(),
+            shinyWidgets::actionBttn(
+                inputId = "reset_draggable_panel_positions",
+                label = "Reset panel positions",
+                 style = "gradient",
+                color = "primary",
+                size = 'xs',
+                no_outline = FALSE,
+                icon = icon("refresh")
+              ),
             shiny::tags$br()
           ),
           shinydashboard::menuItem(

--- a/R/updates_variables_selection_csvA.R
+++ b/R/updates_variables_selection_csvA.R
@@ -32,7 +32,7 @@ updates_variables_selection_csvA <- function(
 
           A2 <- numeric_to_integer(A)
 
-          integers_A <- names(which(unlist(lapply(A2,is.integer))))
+          integers_A <- names(which(unlist(lapply(A2,is.numeric))))
 
           if (shiny::isRunning()) {
             shiny::updateSelectInput(

--- a/R/updates_variables_selection_csvB.R
+++ b/R/updates_variables_selection_csvB.R
@@ -32,7 +32,7 @@ updates_variables_selection_csvB <- function(
 
           B2 <- numeric_to_integer(B)
 
-          integers_B <- names(which(unlist(lapply(B2,is.integer))))
+          integers_B <- names(which(unlist(lapply(B2,is.numeric))))
 
           if (shiny::isRunning()) {
             shiny::updateSelectInput(

--- a/R/updates_variables_selection_file.R
+++ b/R/updates_variables_selection_file.R
@@ -18,10 +18,13 @@ updates_variables_selection_file <- function(
     utils::tail(strsplit(file$datapath, ".", fixed = TRUE)[[1]], n = 1) %in% c("RData","rdata","Rdata")
   ) {
   load(file$datapath)
+
     A2 <- numeric_to_integer(A)
     B2 <- numeric_to_integer(B)
 
-    integers_A <- names(which(unlist(lapply(A2,is.integer))))
+    integers_A <- names(which(unlist(lapply(A2,is.numeric))))
+
+
     shiny::updateSelectInput(
       session,
       inputId = "A_subjectid_rdata",
@@ -40,7 +43,7 @@ updates_variables_selection_file <- function(
       choices = integers_A,
       selected = integers_A[3]
     )
-    integers_B <- names(which(unlist(lapply(B2,is.integer))))
+    integers_B <- names(which(unlist(lapply(B2,is.numeric))))
     shiny::updateSelectInput(
       session,
       inputId = "B_subjectid_rdata",

--- a/R/updates_variables_selection_rdataA.R
+++ b/R/updates_variables_selection_rdataA.R
@@ -17,7 +17,7 @@ updates_variables_selection_rdataA <- function(
           A <- get(load(file$datapath))
           A2 <- numeric_to_integer(A)
 
-          integers_A <- names(which(unlist(lapply(A2,is.integer))))
+          integers_A <- names(which(unlist(lapply(A2,is.numeric))))
 
           if (shiny::isRunning()) {
             shiny::updateSelectInput(

--- a/R/updates_variables_selection_rdataB.R
+++ b/R/updates_variables_selection_rdataB.R
@@ -17,7 +17,7 @@ updates_variables_selection_rdataB <- function(
           B <- get(load(file$datapath))
           B2 <- numeric_to_integer(B)
 
-          integers_B <- names(which(unlist(lapply(B2,is.integer))))
+          integers_B <- names(which(unlist(lapply(B2,is.numeric))))
 
           if (shiny::isRunning()) {
             shiny::updateSelectInput(

--- a/R/utils_numeric_to_integer.R
+++ b/R/utils_numeric_to_integer.R
@@ -13,17 +13,17 @@ numeric_to_integer <- function(df) {
       if (dim(df)[1] != 0) {
         df <- data.frame(df)
         for(i in 1:dim(df)[2]) {
-          if (!is.character(df[,i])) {
+          # if (!is.character(df[,i])) {
             if (all(!is.na(df[,i]))) {
               #check if values are smaller than machines maximal integer
               if (all(df[,i] <= .Machine$integer.max)) {
-                if (all(stats::na.omit(df[,i] == as.integer(df[,i])))) {
-                  df[,i] <- as.integer(df[,i])
+                if (all(stats::na.omit(df[,i] == as.numeric(df[,i])))) {
+                  df[,i] <- as.numeric(df[,i])
                 }
               }
               # create note for cases where integer.max is reached
             }
-          }
+          # }
         }
       }
     }

--- a/tests/testthat/test-updates_variables_selection_rdataA.R
+++ b/tests/testthat/test-updates_variables_selection_rdataA.R
@@ -6,19 +6,19 @@ test_that("updates_variables_selection_rdataA() checks", {
     end_time = c(53,52,70)
   )
   path_rdata <- paste0(tempfile(), ".rdata")
-  save(A, file = path_rdata)  
+  save(A, file = path_rdata)
   expect_equal(
     updates_variables_selection_rdataA(
       file = data.frame(
         name = "Test.rdata",
-        size = 1234,        
+        size = 1234,
         type = "",
         datapath = path_rdata
       )
     ),
     c("subjectid","start_time","end_time")
   )
-  
+
   # Define a simple test dataframe A2 with two integer variables and one character
   # variable. The character variable should not be returned in this case
   A2 <- data.frame(
@@ -27,20 +27,20 @@ test_that("updates_variables_selection_rdataA() checks", {
     end_time = c(53,52,70)
   )
   path_rdata <- paste0(tempfile(), ".rdata")
-  save(A2, file = path_rdata)  
+  save(A2, file = path_rdata)
   expect_equal(
     updates_variables_selection_rdataA(
       file = data.frame(
         name = "Test.rdata",
-        size = 1234,        
+        size = 1234,
         type = "",
         datapath = path_rdata
       )
     ),
     c("start_time","end_time")
   )
-  
-  # Define a simple test dataframe A3 with all character variables. 
+
+  # Define a simple test dataframe A3 with all character variables.
   # The expected output is then an empty character(0) object
   A3 <- data.frame(
     subjectid = c("one","two","three"),
@@ -48,36 +48,36 @@ test_that("updates_variables_selection_rdataA() checks", {
     end_time = c("one","two","three")
   )
   path_rdata <- paste0(tempfile(), ".rdata")
-  save(A3, file = path_rdata)  
+  save(A3, file = path_rdata)
   expect_equal(
     updates_variables_selection_rdataA(
       file = data.frame(
         name = "Test.rdata",
-        size = 1234,        
+        size = 1234,
         type = "",
         datapath = path_rdata
       )
     ),
     character(0)
   )
-  
+
   A4 <- data.frame(
     subjectid = c("100","101","102"),
     start_time = c("1", "2", "-3"),
     end_time = c("53","52","70")
   )
   path_rdata <- paste0(tempfile(), ".rdata")
-  save(A4, file = path_rdata)  
+  save(A4, file = path_rdata)
   expect_equal(
     updates_variables_selection_rdataA(
       file = data.frame(
         name = "Test.rdata",
-        size = 1234,        
+        size = 1234,
         type = "",
         datapath = path_rdata
       )
     ),
-    character(0)
+    c("subjectid","start_time")
   )
   #If the file ending is not .csv, expect returning character(0) since no integer
   #variable is available
@@ -87,43 +87,43 @@ test_that("updates_variables_selection_rdataA() checks", {
       file = data.frame(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = path_rdata
       )
     )
   )
-  
-  # Expect a warning, when entering list instead of a dataframe as file input 
+
+  # Expect a warning, when entering list instead of a dataframe as file input
   expect_warning(
     updates_variables_selection_rdataA(
       file = list(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = path_rdata
       )
     ), "parameter 'file' needs to be of class data.frame in function updates_variables_selection_rdataA"
   )
-  
+
   # Expect warning when datapath is an empty character string
   expect_warning(
     updates_variables_selection_rdataA(
       file = data.frame(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = ""
       )
     ), "datapath is of length 0 in updates_variables_selection_rdataA"
   )
-  
+
   # Expect warning when datapath is non character
   expect_warning(
     updates_variables_selection_rdataA(
       file = data.frame(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = 123
       )
     ), "datapath is non character in updates_variables_selection_rdataA"

--- a/tests/testthat/test-updates_variables_selection_rdataB.R
+++ b/tests/testthat/test-updates_variables_selection_rdataB.R
@@ -7,19 +7,19 @@ test_that("updates_variables_selection_rdataB() checks", {
   )
   path_rdata <- paste0(tempfile(), ".rdata")
   save(B, file = path_rdata)
-    
+
   expect_equal(
     updates_variables_selection_rdataB(
       file = data.frame(
         name = "Test.rdata",
-        size = 1234,        
+        size = 1234,
         type = "",
         datapath = path_rdata
       )
     ),
     c("subjectid","event_time")
   )
-  
+
   # Define a simple test dataframe A2 with two integer variables and one character
   # variable. The character variable should not be returned in this case
   B2 <- data.frame(
@@ -33,14 +33,14 @@ test_that("updates_variables_selection_rdataB() checks", {
       file = data.frame(
         name = "Test.rdata",
         size = 1234,
-        type = "",  
+        type = "",
         datapath = path_rdata
       )
     ),
     c("event_time")
   )
-  
-  # Define a simple test dataframe A3 with all character variables. 
+
+  # Define a simple test dataframe A3 with all character variables.
   # The expected output is then an empty character(0) object
   B3 <- data.frame(
     subjectid = c("one","two","three"),
@@ -53,13 +53,13 @@ test_that("updates_variables_selection_rdataB() checks", {
       file = data.frame(
         name = "Test.rdata",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = path_rdata
       )
     ),
     character(0)
   )
-  
+
   B4 <- data.frame(
     subjectid = c("100","101","102"),
     event_time = c("50","52","70"),
@@ -71,13 +71,13 @@ test_that("updates_variables_selection_rdataB() checks", {
       file = data.frame(
         name = "Test.rdata",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = path_rdata
       )
     ),
-    character(0)
+    c("subjectid")
   )
-  
+
   #If the file ending is not .rdata, expect returning character(0) since no integer
   #variable is available
   path_rdata <- paste0(tempfile(), ".abc")
@@ -86,43 +86,43 @@ test_that("updates_variables_selection_rdataB() checks", {
       file = data.frame(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = path_rdata
       )
     )
   )
-  
-  # Expect a warning, when entering list instead of a dataframe as file input 
+
+  # Expect a warning, when entering list instead of a dataframe as file input
   expect_warning(
     updates_variables_selection_rdataB(
       file = list(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = path_rdata
       )
     ), "parameter 'file' needs to be of class data.frame in function updates_variables_selection_rdataB"
   )
-  
+
   # Expect warning when datapath is an empty character string
   expect_warning(
     updates_variables_selection_rdataB(
       file = data.frame(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = ""
       )
     ), "datapath is of length 0 in updates_variables_selection_rdataB"
   )
-  
+
   # Expect warning when datapath is non character
   expect_warning(
     updates_variables_selection_rdataB(
       file = data.frame(
         name = "Test.abc",
         size = 1234,
-        type = "", 
+        type = "",
         datapath = 123
       )
     ), "datapath is non character in updates_variables_selection_rdataB"

--- a/tests/testthat/test-utils_numeric_to_integer.R
+++ b/tests/testthat/test-utils_numeric_to_integer.R
@@ -8,32 +8,34 @@ test_that("numeric_to_integer() checks", {
     character = c("one","two","three"),
     character_integer = c("1", "2", "3")
   )
-  
+
   df2 <- data.frame(
     numeric_decimal = c(1.5,2,2.5),
     integer_to_big = as.numeric(c(10000000000,20000000000,30000000000)),
     character = c("one","two","three"),
     character_integer = c("1", "2", "3")
   )
-  
+
   df3 <- data.frame(empty = NULL)
-  
-  #expect to transform structure numeric to integer if variables 
+
+  #expect to transform structure numeric to integer if variables
   #includes only integers, except integers which are outside the maximal
   #machine integer
   expect_false(is.integer(numeric_to_integer(df)$numeric_decimal))
-  expect_true(is.integer(numeric_to_integer(df)$numeric_integer))
-  expect_true(is.integer(numeric_to_integer(df)$integer))
+  expect_equal(is.integer(numeric_to_integer(df)$numeric_integer), FALSE)
+  expect_equal(is.numeric(numeric_to_integer(df)$numeric_integer), TRUE)
+  expect_equal(is.integer(numeric_to_integer(df)$integer),FALSE)
+  expect_equal(is.numeric(numeric_to_integer(df)$integer),TRUE)
   expect_false(is.integer(numeric_to_integer(df)$integer_to_big))
   expect_false(is.integer(numeric_to_integer(df)$character))
   expect_false(is.integer(numeric_to_integer(df)$character_integer))
-  
+
   #if no variable includes integers expect no transformation
   expect_equal(numeric_to_integer(df2),df2)
-  
+
   #for empty data.frames or NULL value expect return of input
   expect_null(numeric_to_integer(NULL),NULL)
   expect_equal(numeric_to_integer(df3),df3)
-  
+
   expect_equal(numeric_to_integer("Test"),"Test")
 })


### PR DESCRIPTION
fix issue with too long integers as subject identifier

https://github.com/Bayer-Group/BIC-megaplots/issues/4

fix bug with hidden draggable panels

https://github.com/Bayer-Group/BIC-megaplots/issues/3

app_server.R:
-fix font size of subject identifier on y-axis for main plot and zoom-panel -add new observer to react when new button "reset panel position" is clicked (re-create panels)

app_ui.R:
- add actionButton 'reset_draggable_panel_positions'

updates_variables_selection_csvA.R:
-change 'is.integer' to is.numeric to avoid stricter restriction

updates_variables_selection_csvB.R:
-change 'is.integer' to is.numeric to avoid stricter restriction

updates_variables_selection_file.R:
-change 'is.integer' to is.numeric to avoid stricter restriction

updates_variables_selection_rdataA.R:
-change 'is.integer' to is.numeric to avoid stricter restriction

updates_variables_selection_rdataB.R:
-change 'is.integer' to is.numeric to avoid stricter restriction

utils_numeric_to_integer.R:
-change 'is.integer' to is.numeric to avoid stricter restriction -remove restriction that subject identifier can not be character

Change test files to match new updates