### PR TITLE
38 update GitHub actions

### DIFF
--- a/.github/workflows/deployment-posit.yml
+++ b/.github/workflows/deployment-posit.yml
@@ -21,7 +21,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/deployment-posit.yml
+++ b/.github/workflows/deployment-posit.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract R version from renv.lock
         run: | # Extract R version from renv.lock using jq and storing it as an environment variable


### PR DESCRIPTION
Update `actions/checkout` from v4 to v6 to comply with GitHub Actions Nodes.js version requirements