### PR TITLE
Fix #48: add_events fails when input uses Megaplots output column names

### DIFF
--- a/R/fct_helpers_create_file.R
+++ b/R/fct_helpers_create_file.R
@@ -26,14 +26,14 @@ calc_time_to_first <- function(
 
   # Calculate time to first event if requested
   if (calc_event) {
-    data_time_to_first <- data %>%
+    data_time_to_first <- data |>
       dplyr::arrange(
         .data$subjectid,
         .data$event_group,
         .data$event,
         .data$event_time
-      ) %>%
-      dplyr::group_by(.data$subjectid, .data$event_group, .data$event) %>%
+      ) |>
+      dplyr::group_by(.data$subjectid, .data$event_group, .data$event) |>
       # Use ifelse to handle cases where all event_time values are NA for a group
       dplyr::summarize(
         first = ifelse(
@@ -42,13 +42,13 @@ calc_time_to_first <- function(
           min(.data$event_time, na.rm = TRUE)
         ),
         .groups = "drop"
-      ) %>%
-      dplyr::distinct() %>%
+      ) |>
+      dplyr::distinct() |>
       dplyr::mutate(
         # Replace punctuation and spaces with underscores for valid column names
         event_group = gsub("[[:punct:][:space:]]+", "_", .data$event_group),
         event = gsub("[[:punct:][:space:]]+", "_", .data$event)
-      ) %>%
+      ) |>
       tidyr::pivot_wider(
         id_cols = "subjectid",
         names_from = c("event_group", "event"),
@@ -60,14 +60,14 @@ calc_time_to_first <- function(
 
   # Calculate time to first event group if requested
   if (calc_event_group) {
-    data_time_to_first_group <- data %>%
-      dplyr::select(-"event") %>%
+    data_time_to_first_group <- data |>
+      dplyr::select(-"event") |>
       dplyr::arrange(
         .data$subjectid,
         .data$event_group,
         .data$event_time
-      ) %>%
-      dplyr::group_by(.data$subjectid, .data$event_group) %>%
+      ) |>
+      dplyr::group_by(.data$subjectid, .data$event_group) |>
       dplyr::summarize(
         first = ifelse(
           all(is.na(.data$event_time)),
@@ -75,12 +75,12 @@ calc_time_to_first <- function(
           min(.data$event_time, na.rm = TRUE)
         ),
         .groups = "drop"
-      ) %>%
-      dplyr::distinct() %>%
+      ) |>
+      dplyr::distinct() |>
       dplyr::mutate(
         # Replace punctuation and spaces with underscores for valid column names
         event_group = gsub("[[:punct:][:space:]]+", "_", .data$event_group)
-      ) %>%
+      ) |>
       tidyr::pivot_wider(
         id_cols = "subjectid",
         names_from = "event_group",
@@ -89,7 +89,7 @@ calc_time_to_first <- function(
         values_from = "first"
       )
     if (calc_event) {
-      data_time_to_first <- data_time_to_first %>%
+      data_time_to_first <- data_time_to_first |>
         dplyr::left_join(data_time_to_first_group, by = "subjectid")
     } else {
       data_time_to_first <- data_time_to_first_group
@@ -127,14 +127,14 @@ calc_days_with <- function(
     stop("Error: One of calc_event_group and calc_event must be TRUE.")
   }
   if (calc_event) {
-    data_days_with <- data %>%
+    data_days_with <- data |>
       dplyr::arrange(
         .data$subjectid,
         .data$event_group,
         .data$event,
         .data$event_time,
         .data$event_time_end
-      ) %>%
+      ) |>
       dplyr::mutate(
         # Expand each interval to a day sequence to count unique covered days
         days = purrr::map2(
@@ -150,19 +150,19 @@ calc_days_with <- function(
             NULL
           }
         )
-      ) %>%
-      dplyr::group_by(.data$subjectid, .data$event_group, .data$event) %>%
+      ) |>
+      dplyr::group_by(.data$subjectid, .data$event_group, .data$event) |>
       dplyr::summarize(
         # Count unique days across all events for each subject
         days_with = dplyr::n_distinct(unlist(.data$days)),
         .groups = "drop"
-      ) %>%
-      dplyr::distinct() %>%
+      ) |>
+      dplyr::distinct() |>
       dplyr::mutate(
         # Replace punctuation and spaces with underscores for valid column names
         event_group = gsub("[[:punct:][:space:]]+", "_", .data$event_group),
         event = gsub("[[:punct:][:space:]]+", "_", .data$event)
-      ) %>%
+      ) |>
       tidyr::pivot_wider(
         id_cols = "subjectid",
         names_from = c("event_group", "event"),
@@ -173,14 +173,14 @@ calc_days_with <- function(
       )
   }
   if (calc_event_group) {
-    data_days_with_group <- data %>%
-      dplyr::select(-.data$event) %>%
+    data_days_with_group <- data |>
+      dplyr::select(-.data$event) |>
       dplyr::arrange(
         .data$subjectid,
         .data$event_group,
         .data$event_time,
         .data$event_time_end
-      ) %>%
+      ) |>
       dplyr::mutate(
         # Expand each interval to a day sequence to count unique covered days
         days = purrr::map2(
@@ -196,18 +196,18 @@ calc_days_with <- function(
             NULL
           }
         )
-      ) %>%
-      dplyr::group_by(.data$subjectid, .data$event_group) %>%
+      ) |>
+      dplyr::group_by(.data$subjectid, .data$event_group) |>
       dplyr::summarize(
         # Count unique days across all events in the group for each subject
         days_with = dplyr::n_distinct(unlist(.data$days)),
         .groups = "drop"
-      ) %>%
-      dplyr::distinct() %>%
+      ) |>
+      dplyr::distinct() |>
       dplyr::mutate(
         # Replace punctuation and spaces with underscores for valid column names
         event_group = gsub("[[:punct:][:space:]]+", "_", .data$event_group)
-      ) %>%
+      ) |>
       tidyr::pivot_wider(
         id_cols = "subjectid",
         names_from = c("event_group"),
@@ -217,7 +217,7 @@ calc_days_with <- function(
         values_fill = 0
       )
     if (calc_event) {
-      data_days_with <- data_days_with %>%
+      data_days_with <- data_days_with |>
         dplyr::left_join(data_days_with_group, by = "subjectid")
     } else {
       data_days_with <- data_days_with_group

--- a/R/fct_helpers_create_file.R
+++ b/R/fct_helpers_create_file.R
@@ -254,6 +254,41 @@ read_dataset <- function(path) {
   }
 }
 
+
+#' @noRd
+stage_mp_source_cols <- function(data, col_names, prefix = ".mp_src_") {
+  col_names <- unique(col_names)
+  staged <- character(0)
+  for (col in col_names) {
+    if (!col %in% names(data)) {
+      next
+    }
+    new_name <- paste0(prefix, col)
+    data <- dplyr::rename(
+      data,
+      !!rlang::sym(new_name) := !!rlang::sym(col)
+    )
+    staged[col] <- new_name
+  }
+  list(data = data, staged = staged)
+}
+
+#' @noRd
+map_mp_staged_names <- function(names, staged_map) {
+  vapply(
+    names,
+    function(n) {
+      if (n %in% names(staged_map)) {
+        staged_map[[n]]
+      } else {
+        n
+      }
+    },
+    FUN.VALUE = character(1),
+    USE.NAMES = FALSE
+  )
+}
+
 #' @noRd
 resolve_colname <- function(label, colnames_df) {
   idx <- which(toupper(colnames_df) == toupper(label))

--- a/R/fct_mp_add_events.R
+++ b/R/fct_mp_add_events.R
@@ -66,7 +66,7 @@
 #'   sl_ref_date = "TRTSDT",
 #'   prefix_group = "SOC: ",
 #'   prefix_event = "PT: "
-#' ) %>%
+#' ) |>
 #'   finalize_mp_object()
 #' }
 #' @export
@@ -149,7 +149,7 @@ add_events <- function(
     if (length(sl_ref_date) != 1L) {
       stop("`sl_ref_date` must have length 1.", call. = FALSE)
     }
-    sl_tmp <- data %>%
+    sl_tmp <- data |>
       dplyr::mutate(
         # Create a numeric subject ID by removing non-numeric characters from the specified ID column
         subjectid = as.numeric(base::gsub(
@@ -157,9 +157,9 @@ add_events <- function(
           "",
           as.character(!!rlang::sym(id))
         ))
-      ) %>%
+      ) |>
       # Keep one baseline row per subject when creating minimal mp_builder$sl on the fly
-      dplyr::distinct(.data$subjectid, .keep_all = TRUE) %>%
+      dplyr::distinct(.data$subjectid, .keep_all = TRUE) |>
       dplyr::relocate(.data$subjectid)
 
     # Build mp_builder$sl with subjectid and ref_date from sl_ref_date column or constant
@@ -168,8 +168,8 @@ add_events <- function(
         stop("`sl_ref_date` must not be NA.", call. = FALSE)
       }
       sl_col <- resolve_colname(sl_ref_date, colnames(sl_tmp))
-      mp_builder$sl <- sl_tmp %>%
-        dplyr::select(.data$subjectid, dplyr::all_of(sl_col)) %>%
+      mp_builder$sl <- sl_tmp |>
+        dplyr::select(.data$subjectid, dplyr::all_of(sl_col)) |>
         dplyr::rename(ref_date = !!rlang::sym(sl_col))
       mp_builder$sl$ref_date <- as_date_column(mp_builder$sl$ref_date, sl_col)
     } else if (is.numeric(sl_ref_date)) {
@@ -179,8 +179,8 @@ add_events <- function(
           call. = FALSE
         )
       }
-      mp_builder$sl <- sl_tmp %>%
-        dplyr::select(.data$subjectid) %>%
+      mp_builder$sl <- sl_tmp |>
+        dplyr::select(.data$subjectid) |>
         dplyr::mutate(ref_date = as.numeric(sl_ref_date))
     } else {
       stop(
@@ -198,7 +198,7 @@ add_events <- function(
   if ("end_time" %in% names(mp_builder$sl)) {
     sl_join_cols <- c(sl_join_cols, "end_time")
   }
-  adsl <- mp_builder$sl %>% dplyr::select(tidyselect::all_of(sl_join_cols))
+  adsl <- mp_builder$sl |> dplyr::select(tidyselect::all_of(sl_join_cols))
 
   # Validate event_group and event column specifications ----
   if (
@@ -259,7 +259,7 @@ add_events <- function(
     paste(ev_cols, collapse = ", ")
   )
 
-  data <- data %>%
+  data <- data |>
     #rename and relocate id-variable.
     dplyr::mutate(
       subjectid = as.numeric(gsub(
@@ -295,9 +295,9 @@ add_events <- function(
     }
   }
 
-  data <- data %>%
-    dplyr::filter(.data$subjectid %in% adsl$subjectid) %>%
-    dplyr::left_join(adsl, by = "subjectid") %>% # Join to add ref_date and potential start_time / end_time for left censoring
+  data <- data |>
+    dplyr::filter(.data$subjectid %in% adsl$subjectid) |>
+    dplyr::left_join(adsl, by = "subjectid") |> # Join to add ref_date and potential start_time / end_time for left censoring
     dplyr::relocate(.data$subjectid, .data$ref_date)
 
   event_start <- resolve_first_match(event_start, colnames(data), data = data)
@@ -324,15 +324,15 @@ add_events <- function(
   }
 
   # Filter to rows with non-missing and non-empty values in all event_group and event columns, then create event_group and event by pasting together specified columns with optional prefixes.
-  data_tmp <- data %>%
+  data_tmp <- data |>
     dplyr::filter(dplyr::if_all(
       dplyr::all_of(eg_cols),
       ~ !is.na(.) & . != ""
-    )) %>%
+    )) |>
     dplyr::filter(dplyr::if_all(
       dplyr::all_of(ev_cols),
       ~ !is.na(.) & . != ""
-    )) %>%
+    )) |>
     dplyr::mutate(
       event_group = paste0(
         prefix_group,
@@ -348,7 +348,7 @@ add_events <- function(
           c(dplyr::across(dplyr::all_of(ev_cols)), sep = "; ")
         )
       )
-    ) %>%
+    ) |>
     dplyr::select(
       .data$subjectid,
       .data$event_group,
@@ -358,8 +358,8 @@ add_events <- function(
       .data$ref_date,
       tidyselect::any_of(c("start_time", "end_time")),
       tidyselect::any_of(keep_vars)
-    ) %>%
-    dplyr::filter(!is.na(!!rlang::sym(event_start))) %>%
+    ) |>
+    dplyr::filter(!is.na(!!rlang::sym(event_start))) |>
     dplyr::arrange(
       .data$subjectid,
       .data$event_group,
@@ -384,8 +384,8 @@ add_events <- function(
   # Calculate event start and end times relative to ref_date,
   # then apply left censoring to event_time if requested and start_time is available in mp_builder$sl.
   # Original event_start, event_end, and ref_date columns are dropped after calculations.
-  data_tmp <- data_tmp %>%
-    dplyr::group_by(.data$subjectid, .data$event_group, .data$event) %>%
+  data_tmp <- data_tmp |>
+    dplyr::group_by(.data$subjectid, .data$event_group, .data$event) |>
     dplyr::mutate(
       event_time = if (ev_is_date) {
         as.integer(
@@ -419,8 +419,8 @@ add_events <- function(
             1L
         )
       }
-    ) %>%
-    dplyr::ungroup() %>%
+    ) |>
+    dplyr::ungroup() |>
     # left censor data if provided and start_time is available in sl;
     dplyr::mutate(
       event_time = if (is.null(left_censor)) {
@@ -435,17 +435,17 @@ add_events <- function(
           TRUE ~ .data$event_time
         )
       }
-    ) %>%
+    ) |>
     dplyr::select(
       -c(!!rlang::sym(event_start), !!rlang::sym(event_end), .data$ref_date)
-    ) %>% # Drop original date columns
+    ) |> # Drop original date columns
     dplyr::relocate(
       .data$subjectid,
       .data$event_group,
       .data$event,
       .data$event_time,
       .data$event_time_end
-    ) %>% # Rearrange columns
+    ) |> # Rearrange columns
     dplyr::distinct()
 
   time_to_first <- NULL
@@ -453,7 +453,7 @@ add_events <- function(
     message("calculating time to first event")
     time_to_first <- calc_time_to_first(data = data_tmp)
 
-    mp_builder$sl <- mp_builder$sl %>%
+    mp_builder$sl <- mp_builder$sl |>
       dplyr::left_join(time_to_first, by = "subjectid")
   }
 
@@ -462,7 +462,7 @@ add_events <- function(
     message("calculating days with event")
     days_with <- calc_days_with(data = data_tmp)
 
-    mp_builder$sl <- mp_builder$sl %>%
+    mp_builder$sl <- mp_builder$sl |>
       dplyr::left_join(days_with, by = "subjectid")
   }
 

--- a/R/fct_mp_add_events.R
+++ b/R/fct_mp_add_events.R
@@ -296,6 +296,13 @@ add_events <- function(
   }
 
   data <- data |>
+    # Remove unnecessary columns before joining with subject-level data
+    dplyr::select(
+      -dplyr::any_of(setdiff(
+        c("ref_date", "start_time", "end_time"),
+        unique(c(eg_cols, ev_cols))
+      ))
+    ) |>
     dplyr::filter(.data$subjectid %in% adsl$subjectid) |>
     dplyr::left_join(adsl, by = "subjectid") |> # Join to add ref_date and potential start_time / end_time for left censoring
     dplyr::relocate(.data$subjectid, .data$ref_date)
@@ -323,14 +330,27 @@ add_events <- function(
     keep_vars <- character(0)
   }
 
+  # Stage source date columns to internal names to avoid naming conflicts 
+  # when input already uses Megaplots output column names.
+  staged_result <- stage_mp_source_cols(
+    data,
+    unique(c(eg_cols, ev_cols, event_start, event_end))
+  )
+  data <- staged_result$data
+  staged_map <- staged_result$staged
+  eg_cols_use <- map_mp_staged_names(eg_cols, staged_map)
+  ev_cols_use <- map_mp_staged_names(ev_cols, staged_map)
+  src_event_start <- map_mp_staged_names(event_start, staged_map)
+  src_event_end <- map_mp_staged_names(event_end, staged_map)
+
   # Filter to rows with non-missing and non-empty values in all event_group and event columns, then create event_group and event by pasting together specified columns with optional prefixes.
   data_tmp <- data |>
     dplyr::filter(dplyr::if_all(
-      dplyr::all_of(eg_cols),
+      dplyr::all_of(eg_cols_use),
       ~ !is.na(.) & . != ""
     )) |>
     dplyr::filter(dplyr::if_all(
-      dplyr::all_of(ev_cols),
+      dplyr::all_of(ev_cols_use),
       ~ !is.na(.) & . != ""
     )) |>
     dplyr::mutate(
@@ -338,14 +358,14 @@ add_events <- function(
         prefix_group,
         do.call(
           base::paste,
-          c(dplyr::across(dplyr::all_of(eg_cols)), sep = "; ")
+          c(dplyr::across(dplyr::all_of(eg_cols_use)), sep = "; ")
         )
       ),
       event = paste0(
         prefix_event,
         do.call(
           base::paste,
-          c(dplyr::across(dplyr::all_of(ev_cols)), sep = "; ")
+          c(dplyr::across(dplyr::all_of(ev_cols_use)), sep = "; ")
         )
       )
     ) |>
@@ -353,23 +373,23 @@ add_events <- function(
       .data$subjectid,
       .data$event_group,
       .data$event,
-      !!rlang::sym(event_start),
-      !!rlang::sym(event_end),
+      !!rlang::sym(src_event_start),
+      !!rlang::sym(src_event_end),
       .data$ref_date,
       tidyselect::any_of(c("start_time", "end_time")),
       tidyselect::any_of(keep_vars)
     ) |>
-    dplyr::filter(!is.na(!!rlang::sym(event_start))) |>
+    dplyr::filter(!is.na(!!rlang::sym(src_event_start))) |>
     dplyr::arrange(
       .data$subjectid,
       .data$event_group,
       .data$event,
-      !!rlang::sym(event_start),
-      !!rlang::sym(event_end)
+      !!rlang::sym(src_event_start),
+      !!rlang::sym(src_event_end)
     )
 
   # Validate that event_start/event_end and ref_date are on the same scale (dates or numeric); mixed types are not supported.
-  ev_is_date <- is_calendar_date(data_tmp[[event_start]])
+  ev_is_date <- is_calendar_date(data_tmp[[src_event_start]])
   ref_is_date <- is_calendar_date(data_tmp$ref_date)
   if (ev_is_date != ref_is_date) {
     stop(
@@ -389,32 +409,32 @@ add_events <- function(
     dplyr::mutate(
       event_time = if (ev_is_date) {
         as.integer(
-          !!rlang::sym(event_start) - .data$ref_date + 1L
+          !!rlang::sym(src_event_start) - .data$ref_date + 1L
         )
       } else {
-        as.integer(!!rlang::sym(event_start)) -
+        as.integer(!!rlang::sym(src_event_start)) -
           as.integer(.data$ref_date) +
           1L
       },
       event_time_end = if (ev_is_date) {
         dplyr::case_when(
-          !is.na(!!rlang::sym(event_end)) ~ as.integer(
-            !!rlang::sym(event_end) - .data$ref_date + 1L
+          !is.na(!!rlang::sym(src_event_end)) ~ as.integer(
+            !!rlang::sym(src_event_end) - .data$ref_date + 1L
           ),
           # Open events are treated as one-day events at start date
           TRUE ~ as.integer(
-            !!rlang::sym(event_start) - .data$ref_date + 1L
+            !!rlang::sym(src_event_start) - .data$ref_date + 1L
           )
         )
       } else {
         dplyr::case_when(
-          !is.na(!!rlang::sym(event_end)) ~ as.integer(
-            !!rlang::sym(event_end)
+          !is.na(!!rlang::sym(src_event_end)) ~ as.integer(
+            !!rlang::sym(src_event_end)
           ) -
             as.integer(.data$ref_date) +
             1L,
           # Open events are treated as one-day events at start date
-          TRUE ~ as.integer(!!rlang::sym(event_start)) -
+          TRUE ~ as.integer(!!rlang::sym(src_event_start)) -
             as.integer(.data$ref_date) +
             1L
         )
@@ -437,8 +457,8 @@ add_events <- function(
       }
     ) |>
     dplyr::select(
-      -c(!!rlang::sym(event_start), !!rlang::sym(event_end), .data$ref_date)
-    ) |> # Drop original date columns
+      -dplyr::any_of(unique(c(src_event_start, src_event_end))), 
+      -.data$ref_date) |> # Drop original date columns
     dplyr::relocate(
       .data$subjectid,
       .data$event_group,

--- a/R/fct_mp_add_sl.R
+++ b/R/fct_mp_add_sl.R
@@ -169,8 +169,20 @@ add_sl_data <- function(
   )
   message(sprintf("Relative day 1: %s", relative_day_1)) # Message for relative day 1
 
+  # Stage source date columns to internal names to avoid naming conflicts 
+  # when input already uses Megaplots output column names.
+  staged_result <- stage_mp_source_cols(
+    adsl,
+    unique(c(display_start_date, display_end_date, relative_day_1))
+  )
+  adsl <- staged_result$data
+  staged_map <- staged_result$staged
+  display_start_date <- map_mp_staged_names(display_start_date, staged_map)
+  display_end_date <- map_mp_staged_names(display_end_date, staged_map)
+  relative_day_1 <- map_mp_staged_names(relative_day_1, staged_map)
+
   # Collect all date columns to be processed
-  date_cols <- c(display_start_date, display_end_date, relative_day_1)
+  date_cols <- unique(c(display_start_date, display_end_date, relative_day_1))
 
   # Mutate the dataset to create new date-related columns
   adsl <- adsl |>

--- a/R/fct_mp_add_sl.R
+++ b/R/fct_mp_add_sl.R
@@ -169,7 +169,7 @@ add_sl_data <- function(
   )
   message(sprintf("Relative day 1: %s", relative_day_1)) # Message for relative day 1
 
-  # Stage source date columns to internal names to avoid naming conflicts 
+  # Stage source date columns to internal names to avoid naming conflicts
   # when input already uses Megaplots output column names.
   staged_result <- stage_mp_source_cols(
     adsl,
@@ -204,6 +204,10 @@ add_sl_data <- function(
 
   adsl <- adsl |>
     dplyr::relocate("subjectid", "start_time", "end_time", "ref_date") # Rearrange columns without treatment
+
+  if (length(staged_map)) {
+    adsl <- dplyr::select(adsl, -dplyr::all_of(unname(staged_map)))
+  }
 
   mp_builder$sl <- adsl
   return(mp_builder)

--- a/R/fct_mp_add_sl.R
+++ b/R/fct_mp_add_sl.R
@@ -29,7 +29,7 @@
 #'
 #' data(adam_adsl, adam_adae, adam_adlbc, package = "safetyData")
 #'
-#' mp_data <- add_sl_data(adam_adsl) %>%
+#' mp_data <- add_sl_data(adam_adsl) |>
 #'   add_events(
 #'     adam_adae,
 #'     event_group = "AEBODSYS",
@@ -38,13 +38,13 @@
 #'     prefix_event = "PT: ",
 #'     calc_time_to_first = TRUE,
 #'     calc_days_with = TRUE
-#'   ) %>%
+#'   ) |>
 #'   add_events(
 #'     adam_adae,
 #'     event_group = "CQ01NAM",
 #'     event = "AETERM",
 #'     prefix_group = "CQ: "
-#'   ) %>%
+#'   ) |>
 #'   add_events(
 #'     adam_adlbc,
 #'     event_group = "PARAM",
@@ -52,13 +52,14 @@
 #'     event_start = "ADT",
 #'     event_end = "ADT",
 #'     prefix_group = "Lab: "
-#'   ) %>%
+#'   ) |>
 #'   finalize_mp_object(
 #'     event_group_label_case = "title",
 #'     event_label_case = "title"
 #'   )
 #' }
 #' @export
+#' @importFrom dplyr "%>%"
 add_sl_data <- function(
   mp_builder = NULL,
   sl_data = NULL,
@@ -127,7 +128,7 @@ add_sl_data <- function(
       } else {
         .
       }
-    } %>%
+    } |>
     # Create a numeric subject ID and relocate it to the front
     dplyr::mutate(
       subjectid = as.numeric(base::gsub(
@@ -135,7 +136,7 @@ add_sl_data <- function(
         "",
         as.character(!!rlang::sym(id))
       ))
-    ) %>%
+    ) |>
     dplyr::relocate(.data$subjectid)
 
   # Determine the appropriate reference start date
@@ -172,10 +173,13 @@ add_sl_data <- function(
   date_cols <- c(display_start_date, display_end_date, relative_day_1)
 
   # Mutate the dataset to create new date-related columns
-  adsl <- adsl %>%
-    dplyr::mutate(ref_date = !!rlang::sym(relative_day_1)) %>%
+  adsl <- adsl |>
+    dplyr::mutate(ref_date = !!rlang::sym(relative_day_1)) |>
     dplyr::mutate(
-      dplyr::across(tidyselect::all_of(date_cols), ~ as_date_column(.x, dplyr::cur_column())), # Convert specified date columns to Date type
+      dplyr::across(
+        tidyselect::all_of(date_cols),
+        ~ as_date_column(.x, dplyr::cur_column())
+      ), # Convert specified date columns to Date type
       start_time = as.integer(
         !!rlang::sym(display_start_date) - !!rlang::sym(relative_day_1) + 1L
       ), # Calculate start time relative to day 1
@@ -186,7 +190,7 @@ add_sl_data <- function(
       ) # Calculate end time
     )
 
-  adsl <- adsl %>%
+  adsl <- adsl |>
     dplyr::relocate("subjectid", "start_time", "end_time", "ref_date") # Rearrange columns without treatment
 
   mp_builder$sl <- adsl

--- a/R/fct_mp_finalize.R
+++ b/R/fct_mp_finalize.R
@@ -31,7 +31,7 @@ finalize_mp_object <- function(
     )
   }
 
-  out <- mp_builder$sl %>%
+  out <- mp_builder$sl |>
     dplyr::left_join(
       mp_builder$events,
       # Join by all common columns (e.g., subjectid) to combine subject-level and event data
@@ -76,7 +76,7 @@ finalize_mp_object <- function(
     names(out)
   )
   if (length(arrange_cols)) {
-    out <- out %>% dplyr::arrange(dplyr::across(dplyr::all_of(arrange_cols)))
+    out <- out |> dplyr::arrange(dplyr::across(dplyr::all_of(arrange_cols)))
   }
 
   core_cols <- c(
@@ -88,7 +88,7 @@ finalize_mp_object <- function(
     "event_group",
     "event"
   )
-  out <- out %>% dplyr::relocate(dplyr::any_of(core_cols), .before = 1)
+  out <- out |> dplyr::relocate(dplyr::any_of(core_cols), .before = 1)
 
   return(out)
 }

--- a/man/add_events.Rd
+++ b/man/add_events.Rd
@@ -106,7 +106,7 @@ mp_data <- add_events(
   sl_ref_date = "TRTSDT",
   prefix_group = "SOC: ",
   prefix_event = "PT: "
-) \%>\%
+) |>
   finalize_mp_object()
 }
 }

--- a/man/add_sl_data.Rd
+++ b/man/add_sl_data.Rd
@@ -53,7 +53,7 @@ library(safetyData)
 
 data(adam_adsl, adam_adae, adam_adlbc, package = "safetyData")
 
-mp_data <- add_sl_data(adam_adsl) \%>\%
+mp_data <- add_sl_data(adam_adsl) |>
   add_events(
     adam_adae,
     event_group = "AEBODSYS",
@@ -62,13 +62,13 @@ mp_data <- add_sl_data(adam_adsl) \%>\%
     prefix_event = "PT: ",
     calc_time_to_first = TRUE,
     calc_days_with = TRUE
-  ) \%>\%
+  ) |>
   add_events(
     adam_adae,
     event_group = "CQ01NAM",
     event = "AETERM",
     prefix_group = "CQ: "
-  ) \%>\%
+  ) |>
   add_events(
     adam_adlbc,
     event_group = "PARAM",
@@ -76,7 +76,7 @@ mp_data <- add_sl_data(adam_adsl) \%>\%
     event_start = "ADT",
     event_end = "ADT",
     prefix_group = "Lab: "
-  ) \%>\%
+  ) |>
   finalize_mp_object(
     event_group_label_case = "title",
     event_label_case = "title"

--- a/tests/testthat/test-fct_add_events.R
+++ b/tests/testthat/test-fct_add_events.R
@@ -408,3 +408,95 @@ test_that("add_events messages when only some subjects match subject-level data"
   )
   expect_equal(nrow(mp$events), 1L)
 })
+
+test_that("add_events accepts pre-formatted event_time and event_time_end columns", {
+  adae_pre <- data.frame(
+    USUBJID = c("01-001", "01-002"),
+    AEBODSYS = c("SOC", "SOC"),
+    AEDECOD = c("PTa", "PTb"),
+    event_time = c(2L, 6L),
+    event_time_end = c(3L, 7L),
+    stringsAsFactors = FALSE
+  )
+
+  mp <- add_events(
+    adae_pre,
+    event_group = "AEBODSYS",
+    event = "AEDECOD",
+    event_start = "event_time",
+    event_end = "event_time_end",
+    sl_ref_date = 1L
+  )
+
+  expect_equal(nrow(mp$events), 2L)
+  expect_equal(mp$events$event_time, c(2L, 6L))
+  expect_equal(mp$events$event_time_end, c(3L, 7L))
+})
+
+test_that("add_events accepts pre-formatted event_time columns after add_sl_data", {
+  adae_pre <- data.frame(
+    USUBJID = c("01-001", "01-002"),
+    AEBODSYS = c("SOC", "SOC"),
+    AEDECOD = c("PTa", "PTb"),
+    event_time = as.Date(c("2020-01-02", "2020-01-06")),
+    event_time_end = as.Date(c("2020-01-03", "2020-01-07")),
+    stringsAsFactors = FALSE
+  )
+
+  mp <- mp_with_sl() %>%
+    add_events(
+      adae_pre,
+      event_group = "AEBODSYS",
+      event = "AEDECOD",
+      event_start = "event_time",
+      event_end = "event_time_end"
+    )
+
+  expect_equal(nrow(mp$events), 2L)
+  expect_equal(mp$events$event_time, c(2L, 2L))
+  expect_equal(mp$events$event_time_end, c(3L, 3L))
+})
+
+test_that("add_events accepts pre-formatted event_group and event columns as sources", {
+  adae_pre <- data.frame(
+    USUBJID = c("01-001", "01-002"),
+    event_group = c("G1", "G2"),
+    event = c("E1", "E2"),
+    ASTDT = as.Date(c("2020-01-02", "2020-01-06")),
+    AENDT = as.Date(c("2020-01-03", "2020-01-07")),
+    stringsAsFactors = FALSE
+  )
+
+  mp <- mp_with_sl() %>%
+    add_events(
+      adae_pre,
+      event_group = "event_group",
+      event = "event"
+    )
+
+  expect_equal(nrow(mp$events), 2L)
+  expect_equal(mp$events$event_group, c("G1", "G2"))
+  expect_equal(mp$events$event, c("E1", "E2"))
+})
+
+test_that("add_events joins when events data already has ref_date column", {
+  adae_with_ref <- data.frame(
+    USUBJID = c("01-001", "01-002"),
+    ref_date = as.Date(c("2020-01-01", "2020-01-05")),
+    AEBODSYS = c("SOC", "SOC"),
+    AEDECOD = c("PTa", "PTb"),
+    ASTDT = as.Date(c("2020-01-02", "2020-01-06")),
+    AENDT = as.Date(c("2020-01-03", "2020-01-07")),
+    stringsAsFactors = FALSE
+  )
+
+  mp <- mp_with_sl() %>%
+    add_events(
+      adae_with_ref,
+      event_group = "AEBODSYS",
+      event = "AEDECOD"
+    )
+
+  expect_equal(nrow(mp$events), 2L)
+  expect_equal(mp$events$event_time, c(2L, 2L))
+})

--- a/tests/testthat/test-fct_add_events.R
+++ b/tests/testthat/test-fct_add_events.R
@@ -42,7 +42,7 @@ test_that("add_events initializes builder when mp is omitted", {
 })
 
 test_that("add_events appends rows and applies prefix_group / prefix_event", {
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       events_data = adae_min,
       event_group = "AEBODSYS",
@@ -60,7 +60,7 @@ test_that("add_events resolves event column names case-insensitively", {
   adae <- adae_min
   names(adae) <- c("USUBJID", "aebodsys", "aedecod", "ASTDT", "AENDT")
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae,
       event_group = "AEBODSYS",
@@ -75,7 +75,7 @@ test_that("add_events pastes multiple columns for event_group and event", {
   adae$GRP2 <- c("X", "Y")
   adae$EV2 <- c("aa", "bb")
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae,
       event_group = c("AEBODSYS", "GRP2"),
@@ -97,7 +97,7 @@ test_that("add_events messages and warns for multiple event_group/event columns"
     expect_message(
       expect_message(
         expect_message(
-          mp_with_sl() %>%
+          mp_with_sl() |>
             add_events(
               adae,
               event_group = c("AEBODSYS", "GRP2", "GRP3"),
@@ -114,8 +114,8 @@ test_that("add_events messages and warns for multiple event_group/event columns"
 })
 
 test_that("add_events stacks multiple calls on mp$events", {
-  mp <- mp_with_sl() %>%
-    add_events(adae_min, event_group = "AEBODSYS", event = "AEDECOD") %>%
+  mp <- mp_with_sl() |>
+    add_events(adae_min, event_group = "AEBODSYS", event = "AEDECOD") |>
     add_events(adae_min, event_group = "AEBODSYS", event = "AEDECOD")
 
   expect_equal(nrow(mp$events), 4L)
@@ -189,7 +189,7 @@ test_that("add_events does not require sl_ref_date once mp$sl exists", {
     event_group = "AEBODSYS",
     event = "AEDECOD",
     sl_ref_date = "TRTSTDT"
-  ) %>%
+  ) |>
     add_events(adae_min, event_group = "AEBODSYS", event = "AEDECOD")
 
   expect_equal(nrow(mp$events), 4L)
@@ -201,7 +201,7 @@ test_that("add_events errors when id column is absent", {
   names(bad)[1] <- "SUBJ"
 
   expect_error(
-    mp_with_sl() %>%
+    mp_with_sl() |>
       add_events(bad, event_group = "AEBODSYS", event = "AEDECOD"),
     "The specified id 'USUBJID' is not a column in the dataset."
   )
@@ -212,7 +212,7 @@ test_that("add_events errors when event_group column is absent", {
   names(bad)[2] <- "WRONG"
 
   expect_error(
-    mp_with_sl() %>%
+    mp_with_sl() |>
       add_events(bad, event_group = "AEBODSYS", event = "AEDECOD"),
     "Column 'AEBODSYS' not found in dataset."
   )
@@ -222,7 +222,7 @@ test_that("add_events keeps keep_vars when present", {
   adae <- adae_min
   adae$EXTRA <- c("x", "y")
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae,
       event_group = "AEBODSYS",
@@ -243,19 +243,19 @@ test_that("add_events retains keep_vars across multiple calls and datasets", {
   adae_other$AEDECOD <- c("Headache", "Palpitation")
   adae_other$EXTRA_C <- c("c1", "c2")
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae_same,
       event_group = "AEBODSYS",
       event = "AEDECOD",
       keep_vars = "EXTRA_A"
-    ) %>%
+    ) |>
     add_events(
       adae_same,
       event_group = "AEBODSYS",
       event = "AEDECOD",
       keep_vars = "EXTRA_B"
-    ) %>%
+    ) |>
     add_events(
       adae_other,
       event_group = "AEBODSYS",
@@ -270,7 +270,7 @@ test_that("add_events retains keep_vars across multiple calls and datasets", {
 })
 
 test_that("add_events joins time-to-first columns when calc_time_to_first is TRUE", {
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae_min,
       event_group = "AEBODSYS",
@@ -293,7 +293,7 @@ test_that("add_events skips all-NA earlier event_start candidate", {
     stringsAsFactors = FALSE
   )
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae,
       event_group = "AEBODSYS",
@@ -385,7 +385,7 @@ test_that("add_events errors when no subjects match subject-level data", {
   )
 
   expect_error(
-    mp_with_sl() %>%
+    mp_with_sl() |>
       add_events(events_mismatch, event_group = "AEBODSYS", event = "AEDECOD"),
     regexp = "No subjects match"
   )
@@ -402,7 +402,7 @@ test_that("add_events messages when only some subjects match subject-level data"
   )
 
   expect_message(
-    mp <- mp_with_sl() %>%
+    mp <- mp_with_sl() |>
       add_events(events_partial, event_group = "AEBODSYS", event = "AEDECOD"),
     regexp = "1 of 2 subjects"
   )

--- a/tests/testthat/test-fct_add_events.R
+++ b/tests/testthat/test-fct_add_events.R
@@ -443,7 +443,7 @@ test_that("add_events accepts pre-formatted event_time columns after add_sl_data
     stringsAsFactors = FALSE
   )
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae_pre,
       event_group = "AEBODSYS",
@@ -467,7 +467,7 @@ test_that("add_events accepts pre-formatted event_group and event columns as sou
     stringsAsFactors = FALSE
   )
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae_pre,
       event_group = "event_group",
@@ -490,7 +490,7 @@ test_that("add_events joins when events data already has ref_date column", {
     stringsAsFactors = FALSE
   )
 
-  mp <- mp_with_sl() %>%
+  mp <- mp_with_sl() |>
     add_events(
       adae_with_ref,
       event_group = "AEBODSYS",

--- a/tests/testthat/test-fct_add_sl.R
+++ b/tests/testthat/test-fct_add_sl.R
@@ -178,6 +178,7 @@ test_that("add_sl_data accepts display_start_date column named start_time", {
 
   expect_equal(mp$sl$start_time, c(1L, 1L))
   expect_equal(mp$sl$end_time, c(10L, 11L))
+  expect_false(any(grepl("^\\.mp_src_", names(mp$sl))))
 })
 
 test_that("add_sl_data accepts relative_day_1 column named ref_date", {
@@ -196,4 +197,5 @@ test_that("add_sl_data accepts relative_day_1 column named ref_date", {
 
   expect_equal(mp$sl$start_time, c(1L, 1L))
   expect_equal(mp$sl$ref_date, as.Date(c("2022-01-01", "2022-01-02")))
+  expect_false(any(grepl("^\\.mp_src_", names(mp$sl))))
 })

--- a/tests/testthat/test-fct_add_sl.R
+++ b/tests/testthat/test-fct_add_sl.R
@@ -160,3 +160,40 @@ test_that("add_sl_data accepts ISO character date columns", {
   expect_equal(mp$sl$start_time[[1]], 1L)
   expect_equal(mp$sl$end_time[[1]], 10L)
 })
+
+test_that("add_sl_data accepts display_start_date column named start_time", {
+  adsl <- data.frame(
+    USUBJID = c("001", "002"),
+    start_time = as.Date(c("2022-01-01", "2022-01-02")),
+    RFENDT = as.Date(c("2022-01-10", "2022-01-12")),
+    TRTSTDT = as.Date(c("2022-01-01", "2022-01-02")),
+    stringsAsFactors = FALSE
+  )
+
+  mp <- add_sl_data(
+    adsl,
+    display_start_date = "start_time",
+    relative_day_1 = "TRTSTDT"
+  )
+
+  expect_equal(mp$sl$start_time, c(1L, 1L))
+  expect_equal(mp$sl$end_time, c(10L, 11L))
+})
+
+test_that("add_sl_data accepts relative_day_1 column named ref_date", {
+  adsl <- data.frame(
+    USUBJID = c("001", "002"),
+    REFSTDT = as.Date(c("2022-01-01", "2022-01-02")),
+    RFENDT = as.Date(c("2022-01-10", "2022-01-12")),
+    ref_date = as.Date(c("2022-01-01", "2022-01-02")),
+    stringsAsFactors = FALSE
+  )
+
+  mp <- add_sl_data(
+    adsl,
+    relative_day_1 = "ref_date"
+  )
+
+  expect_equal(mp$sl$start_time, c(1L, 1L))
+  expect_equal(mp$sl$ref_date, as.Date(c("2022-01-01", "2022-01-02")))
+})

--- a/tests/testthat/test-mp_createfile_pipeline.R
+++ b/tests/testthat/test-mp_createfile_pipeline.R
@@ -18,7 +18,7 @@ test_that("builder pipeline with add_sl_data stacks events and finalize returns 
     stringsAsFactors = FALSE
   )
 
-  mp <- add_sl_data(adsl) %>%
+  mp <- add_sl_data(adsl) |>
     add_events(
       adae,
       event_group = "AEBODSYS",
@@ -57,7 +57,7 @@ test_that("data_filter on add_events restricts rows", {
     stringsAsFactors = FALSE
   )
 
-  mp <- add_sl_data(adsl) %>%
+  mp <- add_sl_data(adsl) |>
     add_events(
       adae,
       event_group = "AEBODSYS",


### PR DESCRIPTION
- Fix `add_events()` and `add_sl_data()` when source datasets already contain Megaplots output names (`event_time`, `event_time_end`, `ref_date`, etc.) by renaming source columns to internal `.mp_src_*` names before transformation.
- Drop redundant join columns before the subject-level join in `add_events()` to avoid column conflicts.
- Replace dplyr `%>%` with base `|>` in create-file helpers for consistency.
